### PR TITLE
Update webpack.prod.js

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,4 +1,4 @@
-const merge = require('webpack-merge');
+const {merge} = require('webpack-merge');
 const common = require('./webpack.common.js');
 const Dotenv = require('dotenv-webpack');
 module.exports = merge(common, {


### PR DESCRIPTION
In a new version of webpack-merge, It is imported like below:

const { merge } = require('webpack-merge');

https://stackoverflow.com/questions/62851934/webpack-merge-merge-is-not-a-function