### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # ignore all files starting with .
 .*
+# Note! to deploy this project later on (e.g. vercel.com) you will need to remove the '.*' from the above line. 
 
 # track this file .gitignore (i.e. do NOT ignore it)
 !.gitignore


### PR DESCRIPTION
A comment added to warn students that the '.*' from the beginning of the .gitignore file will need to be removed when trying to deploy the project later on (e.g. on vercel.com). Otherwise, they will face errors or the project won't deploy correctly. 